### PR TITLE
Add Atomix.jl v1 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [compat]
 AcceleratedKernels = "0.2"
 ArgCheck = "2"
-Atomix = "0.1, 0.2"
+Atomix = "0.1, 1"
 DocStringExtensions = "0.9"
 GPUArraysCore = "0.1, 0.2"
 KernelAbstractions = "0.9"


### PR DESCRIPTION
Keep 0.1 compat as no previously-released functionality has been changed.

See [release notes](https://github.com/JuliaConcurrent/Atomix.jl/releases/tag/v1.0.0) and https://github.com/JuliaGPU/KernelAbstractions.jl/pull/545 for more details.

Depends on https://github.com/JuliaGPU/KernelAbstractions.jl/pull/545