### PR TITLE
fix to error in raytracing intersection calculation for points inside…

### DIFF
--- a/src/bounding_volumes/isintersection.jl
+++ b/src/bounding_volumes/isintersection.jl
@@ -64,9 +64,12 @@ end
     discriminant = b * b - T(4) * a * c
 
     if discriminant >= T(0)
-        # Ensure only forwards intersections are counted
-        return T(0) >= b * c
+        if b <= T(0)
+            return true
+        else
+            return T(0) >= c
+        end
     else
         return false
-    end    
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -381,9 +381,9 @@ end
     sphere = BSphere{Float64}(p1,p2,p3)
     bvh = ImplicitBVH.BVH([sphere], ImplicitBVH.BBox{Float64}, UInt64)
 
-    test_x_point_range = (sphere.x[1] - sphere.r):0.1:(sphere.x[1] + sphere.r)
-    test_y_point_range = (sphere.x[2] - sphere.r):0.1:(sphere.x[2] + sphere.r)
-    test_z_point_range = (sphere.x[3] - sphere.r):0.1:(sphere.x[3] + sphere.r)
+    test_x_point_range = (sphere.x[1] - sphere.r):1:(sphere.x[1] + sphere.r)
+    test_y_point_range = (sphere.x[2] - sphere.r):1:(sphere.x[2] + sphere.r)
+    test_z_point_range = (sphere.x[3] - sphere.r):1:(sphere.x[3] + sphere.r)
 
     # Generate a matrix of points to test
     points = [[[x; y; z] for x in test_x_point_range, y in test_y_point_range, z in test_z_point_range]...]


### PR DESCRIPTION
… 
bounding spheres outlined in issue #13. Tests added to catch error in future. For a look into the maths behind the ray sphere intersection calculations look at attached pdf.

[raytracing.pdf](https://github.com/user-attachments/files/18810934/raytracing.pdf)
