### PR TITLE
FIX: CUDA misaligned address (716) error by avoiding merged return in BSphere construction from triangle vertices

### DIFF
--- a/src/bounding_volumes/bsphere.jl
+++ b/src/bounding_volumes/bsphere.jl
@@ -78,6 +78,7 @@ function BSphere{T}(p1, p2, p3) where T
                   T(0.5) * (lower[2] + upper[2]),
                   T(0.5) * (lower[3] + upper[3]))
         radius = dist3(centre, upper)
+        return BSphere(centre, radius)
     else
         s = (abab * acac - acac * abac) / d
         t = (acac * abab - abab * abac) / d
@@ -87,25 +88,27 @@ function BSphere{T}(p1, p2, p3) where T
                       T(0.5) * (a[2] + c[2]),
                       T(0.5) * (a[3] + c[3]))
             radius = dist3(centre, a)
+            return BSphere(centre, radius)
         elseif t <= zero(T)
             centre = (T(0.5) * (a[1] + b[1]),
                       T(0.5) * (a[2] + b[2]),
                       T(0.5) * (a[3] + b[3]))
             radius = dist3(centre, a)
+            return BSphere(centre, radius)
         elseif s + t >= one(T)
             centre = (T(0.5) * (b[1] + c[1]),
                       T(0.5) * (b[2] + c[2]),
                       T(0.5) * (b[3] + c[3]))
             radius = dist3(centre, b)
+            return BSphere(centre, radius)
         else
             centre = (a[1] + s * (b[1] - a[1]) + t * (c[1] - a[1]),
                       a[2] + s * (b[2] - a[2]) + t * (c[2] - a[2]),
                       a[3] + s * (b[3] - a[3]) + t * (c[3] - a[3]))
             radius = dist3(centre, a)
+            return BSphere(centre, radius)
         end
     end
-
-    BSphere(centre, radius)
 end
 
 


### PR DESCRIPTION
Rather than constructing `centre` and `radius` in the branches, and merging before returning, just return inside the branches.

Changed src/bounding_volumes/bsphere.jl

Stella's examples/rotating_drum/rotating_drum.jl now works (05/04/2026) with PrecisionSettings(CUDA) with both single and double precision

Benchmarked and proven equivalent performance:
```
Merged return:
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  105.800 μs …  3.796 ms  ┊ GC (min … max): 0.00% … 0.00%
  ▃▅▃▂▃▃▄▅▅▇███████▆▇███▆▅▅▄▄▃▂▂▂▂▂▂▂▁▁▁▁▂▄▄▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  106 μs          Histogram: frequency by time          168 μs <

 Memory estimate: 704 bytes, allocs estimate: 44.
Early return:
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  105.900 μs …  3.403 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     122.600 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   126.722 μs ± 56.277 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▂█▂▁      ▁▁
  ▂▃▂▂▂▂▃▃▄▄████▇▇▇▆▅▅██▇▅▄▅▄▃▃▂▂▂▁▁▂▁▁▁▁▁▁▂▅▄▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  106 μs          Histogram: frequency by time          166 μs <

 Memory estimate: 208 bytes, allocs estimate: 13.
Median merged: 0.122 ms
Median early : 0.123 ms
```